### PR TITLE
vpnmain.cgi: Moved inclusion of ipsec.user.conf to the end of ipsec.conf...

### DIFF
--- a/html/cgi-bin/vpnmain.cgi
+++ b/html/cgi-bin/vpnmain.cgi
@@ -252,10 +252,6 @@ sub writeipsecfiles {
     print CONF "\tkeyingtries=%forever\n";
     print CONF "\n";
 
-    # Add user includes to config file
-    print CONF "include /etc/ipsec.user.conf\n";
-    print CONF "\n";
-
     print SECRETS "include /etc/ipsec.user.secrets\n";
 
     if (-f "${General::swroot}/certs/hostkey.pem") {
@@ -437,6 +433,12 @@ sub writeipsecfiles {
 	}
 	print CONF "\n";
     }#foreach key
+
+    # Add user includes to config file
+    # After the GUI-connections allows to patch connections.
+    print CONF "include /etc/ipsec.user.conf\n";
+    print CONF "\n";
+
     print SECRETS $last_secrets if ($last_secrets);
     close(CONF);
     close(SECRETS);

--- a/html/cgi-bin/vpnmain.cgi
+++ b/html/cgi-bin/vpnmain.cgi
@@ -437,6 +437,12 @@ sub writeipsecfiles {
 	}
 	print CONF "\n";
     }#foreach key
+
+    # Add post user includes to config file
+    # After the GUI-connections allows to patch connections.
+    print CONF "include /etc/ipsec.user-post.conf\n";
+    print CONF "\n";
+
     print SECRETS $last_secrets if ($last_secrets);
     close(CONF);
     close(SECRETS);

--- a/html/cgi-bin/vpnmain.cgi
+++ b/html/cgi-bin/vpnmain.cgi
@@ -252,6 +252,10 @@ sub writeipsecfiles {
     print CONF "\tkeyingtries=%forever\n";
     print CONF "\n";
 
+    # Add user includes to config file
+    print CONF "include /etc/ipsec.user.conf\n";
+    print CONF "\n";
+
     print SECRETS "include /etc/ipsec.user.secrets\n";
 
     if (-f "${General::swroot}/certs/hostkey.pem") {
@@ -433,12 +437,6 @@ sub writeipsecfiles {
 	}
 	print CONF "\n";
     }#foreach key
-
-    # Add user includes to config file
-    # After the GUI-connections allows to patch connections.
-    print CONF "include /etc/ipsec.user.conf\n";
-    print CONF "\n";
-
     print SECRETS $last_secrets if ($last_secrets);
     close(CONF);
     close(SECRETS);


### PR DESCRIPTION
Hi

... in order to allow connection parameters to be overwritten in ipsec.user.conf.

My use case requires me to "patch" the IPSec connection created in the GUI (or do it entierly in the user.conf, of course). It turns out that this only works if the include for the user conf is after the connections in ipsec.conf.

So I moved the corresponding code down in vpnmain.cgi.

I hope this can be included into IPFire.

Best regards
Christoph 