### PR TITLE
Update updxlrator

### DIFF
--- a/config/updxlrator/updxlrator
+++ b/config/updxlrator/updxlrator
@@ -5,17 +5,20 @@
 # (c) 2006-2009 marco.s - http://update-accelerator.advproxy.net
 #
 # Portions (c) 2008 by dotzball - http://www.blockouttraffic.de
+# Little corrections (c) 2016 by sosyco http://www.sosyco.de
 #
 # $Id: updxlrator,v 2.1 2009/01/10 00:00:00 marco.s Exp $
 #
 # ChangeLog:
 #
+# 2016-02-16: nightshift - correction of caracter-proplems in url
 # 2012-10-26: nightshift - move curly bracket to capture AVG download source.
 #			 - Adding BIG HINT for new update source#
 #
 
 use strict;
 use HTTP::Date;
+use URI::Escape;
 
 $|=1;
 
@@ -112,7 +115,7 @@ while (<>) {
 		($source_url =~ m@^[h|f]t?tp://[^?]+/distfiles/[^?]+\.(tar\.gz|tar\.bz2|tar\.xz|tgz|zip|patch\.bz2|gz|docx|patch|pdf|exe)$@i)
 	)
 	{
-		$xlrator_url = &check_cache($source_url,$hostaddr,$username,"Linux",$mirror);
+		$xlrator_url = &check_cache(uri_unescape($source_url),$hostaddr,$username,"Linux",$mirror);
 	}
 
 	# -----------------------------------------------------------


### PR DESCRIPTION
Quick solution for Cache problems like:
1455649773 xxx.xxx.xxx.xxx/- - Linux DLSOURCE http://archive.ubuntu.com/ubuntu/pool/main/g/gsfonts/gsfonts_8.11%2burwcyr1.0.7%7epre44-4.2ubuntu1_all.deb
1455649782 xxx.xxx.xxx.xxx/- - Linux DLSOURCE http://archive.ubuntu.com/ubuntu/pool/main/g/gsfonts/gsfonts_8.11%2burwcyr1.0.7%7epre44-4.2ubuntu1_all.deb
After modifikation:
1455649832 xxx.xxx.xxx.xxx/- - Linux UPDCACHE http://archive.ubuntu.com/ubuntu/pool/main/g/gsfonts/gsfonts_8.11+urwcyr1.0.7~pre44-4.2ubuntu1_all.deb