### PR TITLE
Update system.cgi page header name

### DIFF
--- a/html/cgi-bin/system.cgi
+++ b/html/cgi-bin/system.cgi
@@ -53,7 +53,7 @@ if ( $querry[0] =~ "cpufreq"){
 	&Graphs::updateloadgraph($querry[1]);
 }else{
 	&Header::showhttpheaders();
-	&Header::openpage($Lang::tr{'status information'}, 1, '');
+	&Header::openpage($Lang::tr{'system information'}, 1, '');
 	&Header::openbigbox('100%', 'left');
 
 	&Header::openbox('100%', 'center', "CPU $Lang::tr{'graph'}");


### PR DESCRIPTION
Page header of "Status Information" changed to "System Information".  Menu name now matches header name.

Sorry if I did a PR to the wrong area.  Wasn't sure if this belonged within "master" or "core119" or somewhere else.